### PR TITLE
Update build-toolchain

### DIFF
--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -109,6 +109,26 @@ while [ $# -ne 0 ]; do
     -a|--no-assert)
       NO_ASSERTIONS=",no_assertions"
   ;;
+    --single-arch)
+      SINGLE_ARCH=1
+      git apply <<SINGLE_ARCH
+diff --git a/utils/build-presets.ini b/utils/build-presets.ini
+index d3e88a1107f..a8be5551f14 100644
+--- a/utils/build-presets.ini
++++ b/utils/build-presets.ini
+@@ -1352,7 +1352,9 @@ release-debuginfo
+ compiler-vendor=apple
+ 
+ # Cross compile for Apple Silicon
+-infer-cross-compile-hosts-on-darwin
++# Temporarilly commented out for
++# build-toolchain <id> --single-arch
++#infer-cross-compile-hosts-on-darwin
+ 
+ lldb-use-system-debugserver
+ lldb-build-type=Release
+SINGLE_ARCH
+  ;;
   -h|--help)
     usage
     exit 0
@@ -172,3 +192,8 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
         darwin_toolchain_version="${TOOLCHAIN_VERSION}" \
         darwin_toolchain_alias="Local" \
         darwin_toolchain_require_use_os_runtime="${REQUIRE_USE_OS_RUNTIME}"
+
+if [ "$SINGLE_ARCH" != "" ]; then
+  git checkout utils/build-presets.ini
+  rm -r ../swift-nightly-{install,symroot}
+fi


### PR DESCRIPTION
Add --single-arch option.

Hi Apple, this patch is a follow up to the [conversation on S/E](https://forums.swift.org/t/unable-to-build-toolchain-due-to-thin-libzstd-dylib/67043/14) related to the difficulty of using the utils/build-toolchain script the introduction of Macs with apple silicon. This add an option --single-arch which by temporally removing the `infer-cross-compile-hosts-on-darwin` option from the `mixin_osx_package_base` preset allows users's to build a toolchain for their current architecture only.

This should probably be the default for this script but as how it goes about it is a little untidy I'll leave it as it is.

Cheers,